### PR TITLE
both apps now behave on boot and redeploy

### DIFF
--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -34,12 +34,13 @@ deploy '/apps/alpha' do
     end
   end
   before_restart do
-    Dir.chdir(release_path) do
-      system('killall -9 ruby1.9.1')
+    execute "restarting app_alpha" do
+      command 'kill -9 $(cat /apps/alpha/shared/rack.pid)'
+      only_if "test -f /apps/alpha/shared/rack.pid"
     end
   end
 
-  restart_command 'bundle exec rackup -D'
+  restart_command 'bundle exec rackup -D -P /apps/alpha/shared/rack.pid'
 end
 
 user 'liftopian'

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -30,16 +30,17 @@ deploy '/apps/beta' do
       directory "/apps/beta/shared/log"
       cookbook_file "/apps/beta/shared/config/database.yml"
       system('bundle --deployment --path /tmp/bundles')
-    end
-  end
-  before_restart do
-    Dir.chdir(release_path) do
-      system('killall -9 ruby1.9.1')
       system('mysqladmin create my_interview_development || echo "Already Created"')
     end
   end
+  before_restart do
+    execute "restarting app_beta" do
+      command 'kill -9 $(cat /apps/beta/shared/rack.pid)'
+      only_if "test -f /apps/beta/shared/rack.pid"
+    end
+  end
 
-  restart_command 'bundle exec rackup -p 9293 -D'
+  restart_command 'bundle exec rackup -p 9293 -D -P /apps/beta/shared/rack.pid'
 end
 
 user 'liftopian'


### PR DESCRIPTION
The problem was, after boot or chef run/deploy only one app was running. This was caused by this:

``` ruby
  before_restart do
    Dir.chdir(release_path) do
      system('killall -9 ruby1.9.1')
    end
  end
```

There's a few things wrong with this, doing a `killall` on a process name can back fire and effect others process of the same name. First `app_alpha` started up and was happy, then we started to deploy `app_beta` and we came around to this block a second time we killed `app_alpha`. This works if the cookbook is ran on it's own, but ideally one cookbook shouldn't effect other. Secondly you really didn't have to be in the `relase_path` to kill a process :smile: 

I think killing process via their ID is a safer way to kill procs, that's why we're also now taking advantage of `rackup`'s ability to manage PID files. From there we can pass the PID of the correct app to `kill`. We get around the first boot problem of there not being a PID number at first run thanks to the `only_if` guard. 

In `app_beta` I moved `system('mysqladmin create my_interview_development || echo "Already Created"')` back up in to the before_migrate block. This would have failed had `app_alpha` not created the database before hand. 
