### PR TITLE
James Brink

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,9 @@ Vagrant.configure('2') do |config|
     chef.add_recipe "vim"
     chef.add_recipe "git"
     chef.add_recipe 'build-essential'
+    chef.add_recipe 'supervisor'
 
+    # applications that should be deployed
     chef.add_recipe 'app_alpha'
     chef.add_recipe 'app_beta'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,8 @@ Vagrant.configure('2') do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://grahamc.com/vagrant/ubuntu-12.04-omnibus-chef.box"
 
-  config.vm.network :forwarded_port, :guest => 9292, :host => 8901
-  config.vm.network :forwarded_port, :guest => 9293, :host => 8902
+  config.vm.network :forwarded_port, :guest => 8901, :host => 8901
+  config.vm.network :forwarded_port, :guest => 8902, :host => 8902
 
   config.ssh.forward_agent = true
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,6 @@ Vagrant.configure('2') do |config|
     chef.add_recipe "git"
     chef.add_recipe 'build-essential'
 
-    chef.add_recipe 'mysql::server'
-    chef.add_recipe 'memcached'
     chef.add_recipe 'app_alpha'
     chef.add_recipe 'app_beta'
 

--- a/cookbooks/app_alpha/files/default/alpha.conf
+++ b/cookbooks/app_alpha/files/default/alpha.conf
@@ -1,5 +1,5 @@
 [program:alpha]
 directory = /apps/alpha/current
-command = bundle exec rackup -P ./tmp/pids/rack.pid
+command = bundle exec unicorn_rails -c ./config/unicorn.rb -E development
 user = liftopian
 autostart = true

--- a/cookbooks/app_alpha/files/default/alpha.conf
+++ b/cookbooks/app_alpha/files/default/alpha.conf
@@ -1,5 +1,5 @@
 [program:alpha]
 directory = /apps/alpha/current
-command = bundle exec unicorn_rails -c ./config/unicorn.rb -E development
+command = bundle exec unicorn_rails -c ./config/unicorn.rb -E production
 user = liftopian
 autostart = true

--- a/cookbooks/app_alpha/files/default/alpha.conf
+++ b/cookbooks/app_alpha/files/default/alpha.conf
@@ -1,0 +1,5 @@
+[program:alpha]
+directory = /apps/alpha/current
+command = bundle exec rackup -P ./tmp/pids/rack.pid
+user = liftopian
+autostart = true

--- a/cookbooks/app_alpha/files/default/database.yml
+++ b/cookbooks/app_alpha/files/default/database.yml
@@ -5,3 +5,11 @@ development:
   username: root
   password:
   pool: 5
+
+production:
+  adapter: mysql2
+  database: my_interview_development
+  host: 127.0.0.1
+  username: root
+  password:
+  pool: 5

--- a/cookbooks/app_alpha/files/default/nginx-alpha.conf
+++ b/cookbooks/app_alpha/files/default/nginx-alpha.conf
@@ -1,0 +1,24 @@
+upstream alpha-app {
+    server unix:/apps/alpha/current/tmp/sockets/unicorn.alpha.sock fail_timeout=0;
+}
+
+server {
+    listen 8901;
+    server_name localhost;
+
+    # Application root, as defined previously
+    root /apps/alpha/current/public;
+
+    try_files $uri/index.html $uri @alpha-app;
+
+    location @alpha-app {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://alpha-app;
+    }
+
+    error_page 500 502 503 504 /500.html;
+    client_max_body_size 4G;
+    keepalive_timeout 10;
+}

--- a/cookbooks/app_alpha/files/default/unicorn.rb
+++ b/cookbooks/app_alpha/files/default/unicorn.rb
@@ -1,0 +1,5 @@
+worker_processes 4
+timeout 10
+preload_app true
+pid "./tmp/pids/rack.pid"
+listen 8901

--- a/cookbooks/app_alpha/files/default/unicorn.rb
+++ b/cookbooks/app_alpha/files/default/unicorn.rb
@@ -2,4 +2,5 @@ worker_processes 4
 timeout 10
 preload_app true
 pid "./tmp/pids/rack.pid"
-listen 8901
+#listen 8901
+listen "/apps/alpha/current/tmp/sockets/unicorn.alpha.sock"

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.6'
+version          '0.1.7'
 
 depends 'ruby'
 depends 'nodejs'
@@ -13,3 +13,4 @@ depends 'mongodb'
 depends 'memcached'
 depends 'mysql'
 depends 'supervisor'
+depends 'nginx'

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4'
+version          '0.1.6'
 
 depends 'ruby'
 depends 'nodejs'
@@ -12,3 +12,4 @@ depends 'redis'
 depends 'mongodb'
 depends 'memcached'
 depends 'mysql'
+depends 'supervisor'

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,4 +4,11 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'
+
+depends 'ruby'
+depends 'nodejs'
+depends 'redis'
+depends 'mongodb'
+depends 'memcached'
+depends 'mysql'

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'

--- a/cookbooks/app_alpha/metadata.rb
+++ b/cookbooks/app_alpha/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_alpha'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -8,12 +8,17 @@
 #
 #
 
-package 'ruby1.9.3'
-package 'libsasl2-dev'
+require_recipe 'ruby'
+require_recipe 'git'
+require_recipe 'nodejs'
+require_recipe 'redis'
+require_recipe 'mongodb'
+require_recipe 'memcached'
+require_recipe 'mysql::server'
+
+# TODO could be put into mysql recipe - mysql::client-dev?
 package 'libmysqlclient-dev'
-package 'nodejs'
-package 'mongodb'
-package 'redis-server'
+package 'libsasl2-dev'
 
 gem_package 'bundler'
 

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -17,16 +17,23 @@ package 'redis-server'
 
 gem_package 'bundler'
 
+user 'liftopian' do
+  comment 'Used to run liftopia applications'
+  home '/apps'
+  shell '/bin/false'
+  system true
+end
+
 directory '/apps' do
-  owner 'vagrant'
-  group 'vagrant'
+  owner 'liftopian'
+  group 'liftopian'
   action :create
-  mode 00774
+  mode 00775
 end
 
 deploy_revision '/apps/alpha' do
-  user 'vagrant'
-  group 'vagrant'
+  user 'liftopian'
+  group 'liftopian'
   repo 'https://github.com/liftopia/myInterview.git'
   migrate true
   migration_command 'bundle exec rake db:migrate'
@@ -52,4 +59,3 @@ deploy_revision '/apps/alpha' do
   restart_command 'bundle exec rackup -D -P ./tmp/pids/rack.pid'
 end
 
-user 'liftopian'

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -17,9 +17,16 @@ package 'redis-server'
 
 gem_package 'bundler'
 
-directory '/apps'
+directory '/apps' do
+  owner 'vagrant'
+  group 'vagrant'
+  action :create
+  mode 00774
+end
 
 deploy '/apps/alpha' do
+  user 'vagrant'
+  group 'vagrant'
   repo 'https://github.com/liftopia/myInterview.git'
   migrate true
   migration_command 'bundle exec rake db:migrate'
@@ -28,6 +35,7 @@ deploy '/apps/alpha' do
     Dir.chdir(release_path) do
       directory "/apps/alpha/shared/config"
       directory "/apps/alpha/shared/log"
+      directory "/apps/alpha/shared/pids"
       cookbook_file "/apps/alpha/shared/config/database.yml"
       system('bundle --deployment --path /tmp/bundles')
       system('mysqladmin create my_interview_development || echo "Already Created"')
@@ -35,11 +43,13 @@ deploy '/apps/alpha' do
   end
   before_restart do
     Dir.chdir(release_path) do
-      system('killall -9 ruby1.9.1')
+      Dir.entries('tmp/pids').each do |pid|
+        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /\.+/
+      end
     end
   end
 
-  restart_command 'bundle exec rackup -D'
+  restart_command 'bundle exec rackup -D -P ./tmp/pids/rack.pid'
 end
 
 user 'liftopian'

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -16,6 +16,7 @@ require_recipe 'mongodb'
 require_recipe 'memcached'
 require_recipe 'mysql::server'
 require_recipe 'supervisor'
+require_recipe 'nginx'
 
 # TODO could be put into mysql recipe - mysql::client-dev?
 package 'libmysqlclient-dev'
@@ -37,8 +38,7 @@ directory '/apps' do
   mode 00775
 end
 
-#deploy_revision '/apps/alpha' do
-deploy '/apps/alpha' do
+deploy_revision '/apps/alpha' do
   user 'liftopian'
   group 'liftopian'
   repo 'https://github.com/liftopia/myInterview.git'
@@ -53,11 +53,20 @@ deploy '/apps/alpha' do
       cookbook_file "/apps/alpha/shared/config/database.yml"
       cookbook_file "/apps/alpha/shared/config/unicorn.rb"
       cookbook_file "/etc/supervisor/conf.d/alpha.conf"
+      cookbook_file "/etc/nginx/conf.d/nginx-alpha.conf"
       system('bundle --deployment --path /var/tmp/bundles')
       system('mysqladmin create my_interview_development || echo "Already Created"')
+      system('bundle exec rake assets:precompile')
     end
   end
 
   restart_command 'supervisorctl reread && supervisorctl update && supervisorctl restart alpha'
-end
 
+  after_restart do
+    execute "reload nginx config" do
+      user 'root'
+      command 'service nginx reload'
+    end
+  end
+
+end

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -24,7 +24,7 @@ directory '/apps' do
   mode 00774
 end
 
-deploy '/apps/alpha' do
+deploy_revision '/apps/alpha' do
   user 'vagrant'
   group 'vagrant'
   repo 'https://github.com/liftopia/myInterview.git'
@@ -44,7 +44,7 @@ deploy '/apps/alpha' do
   before_restart do
     Dir.chdir(release_path) do
       Dir.entries('tmp/pids').each do |pid|
-        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /\.+/
+        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /^\.+$/
       end
     end
   end

--- a/cookbooks/app_alpha/recipes/default.rb
+++ b/cookbooks/app_alpha/recipes/default.rb
@@ -49,7 +49,7 @@ deploy_revision '/apps/alpha' do
       directory "/apps/alpha/shared/log"
       directory "/apps/alpha/shared/pids"
       cookbook_file "/apps/alpha/shared/config/database.yml"
-      system('bundle --deployment --path /tmp/bundles')
+      system('bundle --deployment --path /var/tmp/bundles')
       system('mysqladmin create my_interview_development || echo "Already Created"')
     end
   end

--- a/cookbooks/app_beta/files/default/beta.conf
+++ b/cookbooks/app_beta/files/default/beta.conf
@@ -1,0 +1,5 @@
+[program:beta]
+directory = /apps/beta/current
+command = bundle exec rackup -p 9293 -P ./tmp/pids/rack.pid
+user = liftopian
+autostart = true

--- a/cookbooks/app_beta/files/default/beta.conf
+++ b/cookbooks/app_beta/files/default/beta.conf
@@ -1,5 +1,5 @@
 [program:beta]
 directory = /apps/beta/current
-command = bundle exec unicorn_rails -c ./config/unicorn.rb -E development
+command = bundle exec unicorn_rails -c ./config/unicorn.rb -E production
 user = liftopian
 autostart = true

--- a/cookbooks/app_beta/files/default/beta.conf
+++ b/cookbooks/app_beta/files/default/beta.conf
@@ -1,5 +1,5 @@
 [program:beta]
 directory = /apps/beta/current
-command = bundle exec rackup -p 9293 -P ./tmp/pids/rack.pid
+command = bundle exec unicorn_rails -c ./config/unicorn.rb -E development
 user = liftopian
 autostart = true

--- a/cookbooks/app_beta/files/default/database.yml
+++ b/cookbooks/app_beta/files/default/database.yml
@@ -5,3 +5,11 @@ development:
   username: root
   password:
   pool: 5
+
+production:
+  adapter: mysql2
+  database: my_interview_development
+  host: 127.0.0.1
+  username: root
+  password:
+  pool: 5

--- a/cookbooks/app_beta/files/default/nginx-beta.conf
+++ b/cookbooks/app_beta/files/default/nginx-beta.conf
@@ -1,0 +1,24 @@
+upstream beta-app {
+    server unix:/apps/beta/current/tmp/sockets/unicorn.beta.sock fail_timeout=0;
+}
+
+server {
+    listen 8902;
+    server_name localhost;
+
+    # Application root, as defined previously
+    root /apps/beta/current/public;
+
+    try_files $uri/index.html $uri @beta-app;
+
+    location @beta-app {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://beta-app;
+    }
+
+    error_page 500 502 503 504 /500.html;
+    client_max_body_size 4G;
+    keepalive_timeout 10;
+}

--- a/cookbooks/app_beta/files/default/unicorn.rb
+++ b/cookbooks/app_beta/files/default/unicorn.rb
@@ -2,4 +2,5 @@ worker_processes 4
 timeout 10
 preload_app true
 pid "./tmp/pids/rack.pid"
-listen 8902
+#listen 8902
+listen "/apps/beta/current/tmp/sockets/unicorn.beta.sock"

--- a/cookbooks/app_beta/files/default/unicorn.rb
+++ b/cookbooks/app_beta/files/default/unicorn.rb
@@ -1,0 +1,5 @@
+worker_processes 4
+timeout 10
+preload_app true
+pid "./tmp/pids/rack.pid"
+listen 8902

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.6'
+version          '0.1.7'
 
 depends 'ruby'
 depends 'nodejs'
@@ -13,5 +13,6 @@ depends 'mongodb'
 depends 'memcached'
 depends 'mysql'
 depends 'supervisor'
+depends 'nginx'
 
 

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.4'
+version          '0.1.6'
 
 depends 'ruby'
 depends 'nodejs'
@@ -12,5 +12,6 @@ depends 'redis'
 depends 'mongodb'
 depends 'memcached'
 depends 'mysql'
+depends 'supervisor'
 
 

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,4 +4,13 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'
+
+depends 'ruby'
+depends 'nodejs'
+depends 'redis'
+depends 'mongodb'
+depends 'memcached'
+depends 'mysql'
+
+

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'

--- a/cookbooks/app_beta/metadata.rb
+++ b/cookbooks/app_beta/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'ops@liftopia.com'
 license          'All rights reserved'
 description      'Installs/Configures app_beta'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -24,7 +24,7 @@ directory '/apps' do
   mode 00774
 end
 
-deploy '/apps/beta' do
+deploy_revision '/apps/beta' do
   user 'vagrant'
   group 'vagrant'
   repo 'https://github.com/liftopia/myInterview.git'
@@ -44,7 +44,7 @@ deploy '/apps/beta' do
   before_restart do
     Dir.chdir(release_path) do
       Dir.entries('tmp/pids').each do |pid|
-        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /\.+/
+        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /^\.+$/
       end
     end
   end

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -8,12 +8,16 @@
 #
 #
 
-package 'ruby1.9.3'
+require_recipe 'ruby'
+require_recipe 'git'
+require_recipe 'nodejs'
+require_recipe 'redis'
+require_recipe 'mongodb'
+require_recipe 'memcached'
+require_recipe 'mysql::server'
+
 package 'libsasl2-dev'
 package 'libmysqlclient-dev'
-package 'nodejs'
-package 'mongodb'
-package 'redis-server'
 
 gem_package 'bundler'
 

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -17,16 +17,23 @@ package 'redis-server'
 
 gem_package 'bundler'
 
+user 'liftopian' do
+  comment 'Used to run liftopia applications'
+  home '/apps'
+  shell '/bin/false'
+  system true
+end
+
 directory '/apps' do
-  owner 'vagrant'
-  group 'vagrant'
+  owner 'liftopian'
+  group 'liftopian'
   action :create
-  mode 00774
+  mode 00775
 end
 
 deploy_revision '/apps/beta' do
-  user 'vagrant'
-  group 'vagrant'
+  user 'liftopian'
+  group 'liftopian'
   repo 'https://github.com/liftopia/myInterview.git'
   migrate true
   migration_command 'bundle exec rake db:migrate'
@@ -52,4 +59,3 @@ deploy_revision '/apps/beta' do
   restart_command 'bundle exec rackup -p 9293 -D -P ./tmp/pids/rack.pid'
 end
 
-user 'liftopian'

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -15,6 +15,7 @@ require_recipe 'redis'
 require_recipe 'mongodb'
 require_recipe 'memcached'
 require_recipe 'mysql::server'
+require_recipe 'supervisor'
 
 p# TODO could be put into mysql recipe - mysql::client-dev?
 package 'libmysqlclient-dev'
@@ -36,31 +37,27 @@ directory '/apps' do
   mode 00775
 end
 
-deploy_revision '/apps/beta' do
+#deploy_revision '/apps/beta' do
+deploy '/apps/beta' do
   user 'liftopian'
   group 'liftopian'
   repo 'https://github.com/liftopia/myInterview.git'
   migrate true
   migration_command 'bundle exec rake db:migrate'
-  symlinks {}
+  symlinks ({"config/unicorn.rb" => "config/unicorn.rb", "config/database.yml" => "config/database.yml"})
   before_migrate do
     Dir.chdir(release_path) do
       directory "/apps/beta/shared/config"
       directory "/apps/beta/shared/log"
       directory "/apps/beta/shared/pids"
       cookbook_file "/apps/beta/shared/config/database.yml"
+      cookbook_file "/apps/beta/shared/config/unicorn.rb"
+      cookbook_file "/etc/supervisor/conf.d/beta.conf"
       system('bundle --deployment --path /var/tmp/bundles')
       system('mysqladmin create my_interview_development || echo "Already Created"')
     end
   end
-  before_restart do
-    Dir.chdir(release_path) do
-      Dir.entries('tmp/pids').each do |pid|
-        system("kill -9 `cat tmp/pids/#{pid}`") unless pid =~ /^\.+$/
-      end
-    end
-  end
 
-  restart_command 'bundle exec rackup -p 9293 -D -P ./tmp/pids/rack.pid'
+  restart_command 'supervisorctl reread && supervisorctl update && supervisorctl restart beta'
 end
 

--- a/cookbooks/app_beta/recipes/default.rb
+++ b/cookbooks/app_beta/recipes/default.rb
@@ -16,8 +16,9 @@ require_recipe 'mongodb'
 require_recipe 'memcached'
 require_recipe 'mysql::server'
 
-package 'libsasl2-dev'
+p# TODO could be put into mysql recipe - mysql::client-dev?
 package 'libmysqlclient-dev'
+package 'libsasl2-dev'
 
 gem_package 'bundler'
 
@@ -48,7 +49,7 @@ deploy_revision '/apps/beta' do
       directory "/apps/beta/shared/log"
       directory "/apps/beta/shared/pids"
       cookbook_file "/apps/beta/shared/config/database.yml"
-      system('bundle --deployment --path /tmp/bundles')
+      system('bundle --deployment --path /var/tmp/bundles')
       system('mysqladmin create my_interview_development || echo "Already Created"')
     end
   end

--- a/cookbooks/mongodb/CHANGELOG.md
+++ b/cookbooks/mongodb/CHANGELOG.md
@@ -1,0 +1,9 @@
+mongodb CHANGELOG
+=================
+
+This file is used to list changes made in each version of the mongodb cookbook.
+
+0.1.0
+-----
+- James Brink - Initial release of mongodb
+

--- a/cookbooks/mongodb/README.md
+++ b/cookbooks/mongodb/README.md
@@ -1,0 +1,6 @@
+mongodb Cookbook
+================
+Simple cookbook to install mongodb
+
+
+

--- a/cookbooks/mongodb/metadata.rb
+++ b/cookbooks/mongodb/metadata.rb
@@ -1,0 +1,7 @@
+name             'mongodb'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures mongodb'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/mongodb/recipes/default.rb
+++ b/cookbooks/mongodb/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: app_alpha
+# Cookbook Name:: mongodb
 # Recipe:: default
 #
 # Copyright 2014, Liftopia

--- a/cookbooks/mongodb/recipes/default.rb
+++ b/cookbooks/mongodb/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: app_alpha
+# Recipe:: default
+#
+# Copyright 2014, Liftopia
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+package 'mongodb' do
+	action :install
+end

--- a/cookbooks/nginx/CHANGELOG.md
+++ b/cookbooks/nginx/CHANGELOG.md
@@ -1,0 +1,8 @@
+nginx CHANGELOG
+===============
+
+This file is used to list changes made in each version of the nginx cookbook.
+
+0.1.0
+-----
+- James Brink- Initial release of nginx

--- a/cookbooks/nginx/README.md
+++ b/cookbooks/nginx/README.md
@@ -1,0 +1,4 @@
+nginx Cookbook
+==============
+Simple cookbook for nginx
+

--- a/cookbooks/nginx/metadata.rb
+++ b/cookbooks/nginx/metadata.rb
@@ -1,0 +1,7 @@
+name             'nginx'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures nginx'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/nginx/recipes/default.rb
+++ b/cookbooks/nginx/recipes/default.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: nginx
+# Recipe:: default
+#
+# Copyright 2014, Liftopia
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+package "nginx" do
+  action :install
+end
+
+service "nginx" do
+  action :enable
+  action :start
+end

--- a/cookbooks/nodejs/CHANGELOG.md
+++ b/cookbooks/nodejs/CHANGELOG.md
@@ -1,0 +1,13 @@
+nodejs CHANGELOG
+================
+
+This file is used to list changes made in each version of the nodejs cookbook.
+
+0.1.0
+-----
+- [your_name] - Initial release of nodejs
+
+- - -
+Check the [Markdown Syntax Guide](http://daringfireball.net/projects/markdown/syntax) for help with Markdown.
+
+The [Github Flavored Markdown page](http://github.github.com/github-flavored-markdown/) describes the differences between markdown on github and standard markdown.

--- a/cookbooks/nodejs/README.md
+++ b/cookbooks/nodejs/README.md
@@ -1,0 +1,68 @@
+nodejs Cookbook
+===============
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - nodejs needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List your cookbook attributes here.
+
+e.g.
+#### nodejs::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['nodejs']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### nodejs::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `nodejs` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[nodejs]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/cookbooks/nodejs/metadata.rb
+++ b/cookbooks/nodejs/metadata.rb
@@ -1,0 +1,7 @@
+name             'nodejs'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures nodejs'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/nodejs/recipes/default.rb
+++ b/cookbooks/nodejs/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: nodejs
 # Recipe:: default
 #
-# Copyright 2014, YOUR_COMPANY_NAME
+# Copyright 2014, Liftopia
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/cookbooks/nodejs/recipes/default.rb
+++ b/cookbooks/nodejs/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: nodejs
+# Recipe:: default
+#
+# Copyright 2014, YOUR_COMPANY_NAME
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+package 'nodejs' do
+	action :install
+end

--- a/cookbooks/redis/CHANGELOG.md
+++ b/cookbooks/redis/CHANGELOG.md
@@ -1,0 +1,8 @@
+redis CHANGELOG
+===============
+
+This file is used to list changes made in each version of the redis cookbook.
+
+0.1.0
+-----
+- James Brink - Initial release of redis

--- a/cookbooks/redis/README.md
+++ b/cookbooks/redis/README.md
@@ -1,0 +1,68 @@
+redis Cookbook
+==============
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - redis needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List your cookbook attributes here.
+
+e.g.
+#### redis::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['redis']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### redis::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `redis` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[redis]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/cookbooks/redis/metadata.rb
+++ b/cookbooks/redis/metadata.rb
@@ -1,0 +1,7 @@
+name             'redis'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures redis'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: app_alpha
+# Recipe:: default
+#
+# Copyright 2014, Liftopia
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+package 'redis-server' do
+	action :install
+end

--- a/cookbooks/redis/recipes/default.rb
+++ b/cookbooks/redis/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: app_alpha
+# Cookbook Name:: redis
 # Recipe:: default
 #
 # Copyright 2014, Liftopia

--- a/cookbooks/ruby/CHANGELOG.md
+++ b/cookbooks/ruby/CHANGELOG.md
@@ -1,0 +1,9 @@
+ruby CHANGELOG
+==============
+
+This file is used to list changes made in each version of the ruby cookbook.
+
+0.1.0
+-----
+- James Brink - Initial release of ruby
+

--- a/cookbooks/ruby/README.md
+++ b/cookbooks/ruby/README.md
@@ -1,0 +1,68 @@
+ruby Cookbook
+=============
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - ruby needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List your cookbook attributes here.
+
+e.g.
+#### ruby::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['ruby']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### ruby::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `ruby` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[ruby]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/cookbooks/ruby/metadata.rb
+++ b/cookbooks/ruby/metadata.rb
@@ -1,0 +1,7 @@
+name             'ruby'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures ruby'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/ruby/recipes/default.rb
+++ b/cookbooks/ruby/recipes/default.rb
@@ -1,5 +1,5 @@
 #
-# Cookbook Name:: app_alpha
+# Cookbook Name:: ruby
 # Recipe:: default
 #
 # Copyright 2014, Liftopia

--- a/cookbooks/ruby/recipes/default.rb
+++ b/cookbooks/ruby/recipes/default.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: app_alpha
+# Recipe:: default
+#
+# Copyright 2014, Liftopia
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+package 'ruby1.9.3' do
+	action :install
+end

--- a/cookbooks/supervisor/CHANGELOG.md
+++ b/cookbooks/supervisor/CHANGELOG.md
@@ -1,0 +1,8 @@
+supervisor CHANGELOG
+====================
+
+This file is used to list changes made in each version of the supervisor cookbook.
+
+0.1.0
+-----
+- James Brink - Initial release of supervisor

--- a/cookbooks/supervisor/README.md
+++ b/cookbooks/supervisor/README.md
@@ -1,0 +1,68 @@
+supervisor Cookbook
+===================
+TODO: Enter the cookbook description here.
+
+e.g.
+This cookbook makes your favorite breakfast sandwich.
+
+Requirements
+------------
+TODO: List your cookbook requirements. Be sure to include any requirements this cookbook has on platforms, libraries, other cookbooks, packages, operating systems, etc.
+
+e.g.
+#### packages
+- `toaster` - supervisor needs toaster to brown your bagel.
+
+Attributes
+----------
+TODO: List your cookbook attributes here.
+
+e.g.
+#### supervisor::default
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['supervisor']['bacon']</tt></td>
+    <td>Boolean</td>
+    <td>whether to include bacon</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
+Usage
+-----
+#### supervisor::default
+TODO: Write usage instructions for each cookbook.
+
+e.g.
+Just include `supervisor` in your node's `run_list`:
+
+```json
+{
+  "name":"my_node",
+  "run_list": [
+    "recipe[supervisor]"
+  ]
+}
+```
+
+Contributing
+------------
+TODO: (optional) If this is a public cookbook, detail the process for contributing. If this is a private cookbook, remove this section.
+
+e.g.
+1. Fork the repository on Github
+2. Create a named feature branch (like `add_component_x`)
+3. Write your change
+4. Write tests for your change (if applicable)
+5. Run the tests, ensuring they all pass
+6. Submit a Pull Request using Github
+
+License and Authors
+-------------------
+Authors: TODO: List authors

--- a/cookbooks/supervisor/attributes/default.rb
+++ b/cookbooks/supervisor/attributes/default.rb
@@ -1,0 +1,2 @@
+default["authorization"]["supervisor"]["user"] = "liftopian"
+default["authorization"]["supervisor"]["group"] = "liftopian"

--- a/cookbooks/supervisor/metadata.rb
+++ b/cookbooks/supervisor/metadata.rb
@@ -1,0 +1,7 @@
+name             'supervisor'
+maintainer       'Liftopia'
+maintainer_email 'ops@liftopia.com'
+license          'All rights reserved'
+description      'Installs/Configures supervisor'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.1.0'

--- a/cookbooks/supervisor/recipes/default.rb
+++ b/cookbooks/supervisor/recipes/default.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: supervisor
+# Recipe:: default
+#
+# Copyright 2014, Liftopia
+#
+# All rights reserved - Do Not Redistribute
+#
+#
+
+
+user 'liftopian' do
+  comment 'Used to run liftopia applications'
+  home '/apps'
+  shell '/bin/false'
+  system true
+end
+
+directory "/etc/supervisor" do
+  action :create
+  owner "root"
+  group "root"
+end
+
+template "/etc/supervisor/supervisord.conf" do
+  source "supervisord.erb"
+  mode 0644
+  owner "root"
+  group "root"
+  variables({
+                :supervisor_user => node[:authorization][:supervisor][:user],
+                :supervisor_group => node[:authorization][:supervisor][:group]
+            })
+end
+
+package 'supervisor' do
+  action :install
+  options "-o Dpkg::Options::=--force-confdef"
+end
+
+

--- a/cookbooks/supervisor/templates/default/supervisord.erb
+++ b/cookbooks/supervisor/templates/default/supervisord.erb
@@ -1,0 +1,29 @@
+; supervisor config file
+
+[unix_http_server]
+file=/var/run//supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+chown=<%= @supervisor_user%>:<%= @supervisor_group%>
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run//supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
A friend of mine (@doomspork) mentioned you were looking for DevOps engineers so when I came across the chef-interview repo I knew I had to give it a shot.  I have a number of years of experience managing and maintaining server infrastructures and a passion for solving complicated problems, I think I’d be a good fit and a valuable resource. I’d love to talk with someone if you have time.

Per the README here are my notes to accompany my work:

I started by firing up the Vagrant box to see what the state of the machine was after Chef ran.  My focus was on working from the most important issues down to the least.  As of this writing I have been working with Chef for a little over a week but given the opportunity I could become very proficient with it.

The first thing I did was update the Chef recipes to use a shared pids directory for each application in `{{app-root}}/shared/tmp/pids` because the directory was referenced with symlinks but was missing.  Next I altered the restart command to no longer kill the Ruby process and updated the recipe to use a switch to drop the pid file into the shared directory.  This allows for cleaner application restarts by iterating over any pid files in the shared directory.

My next step was to look into the issue of the application being re-deploy on provision, even though there had been no changes to the application.  After looking at the documentation for the resource `deploy` and the directories on the box it was apparent the correct Chef resource was not being accessed.  As you know, the default behavior for `deploy` is to do a Capistrano style deployment using a timestamp.  To fix the redeployment issue I switched to using `deploy_revision` which relies on the commit hash instead.

After both applications were deploying properly, I moved on to updating the recipes to deploy the application as user “liftopian” which I saw had been created in the recipe but not used.

My next set of changes included some refactoring of the application recipes. I took packages and services I felt could be re-used and turned them into cookbooks such as: Ruby, MongoDB, NodeJS, and Redis. While these cookbooks are simple and made to run only on Ubuntu, doing this will allow for re-use of these common packages and services. If at some point the infrastructure included hosts other than Ubuntu, it might be worthwhile to leverage the community cookbooks.  Extracting these out will allow greater control down the road and separation of concerns.

My last step was to ensure that the Alpha and Beta app would start on boot.  I noticed there was a cookbook for runit which I was not familiar with nor am sure how people were using it. 

After reading a bit of information on the project’s homepage it I realized it was a replacement for upstart or systemd and while I think including a process/service supervisor is a great idea I was turned off by the fact they state the following. 

```
“The program runit is intended to run as Unix process no 1, it is automatically started by the runit-init /sbin/init-replacement if this is started by the kernel.”
```

I feel if runit is used in this capacity it could be problematic especially if you intend to be flexible enough to provision other hosts such as FreeBSD or Solaris.  With the wide variety of init daemons out there right now a process supervisor is great to have, so you don’t spend time writing upstart, systemd, init, or SMF startup scripts.  I ended up choosing Supervisor as it is clean, simple, and works across platforms.  What really caught my eye about Supervisor beyond its features, was that it is **not** intended to be a placement for init.

Prior to this exercise I had never used Supervisor but I must say I am very impressed with the simplicity of the tool, and will likely use it again; I went ahead and created a chef cookbook for it. I also created a template to ensure that the user “liftopian” would be able to start and stop processes, I updated the application recipes to require in this new recipe and dropped in the configuration file for each.

After everything was running, I took a look at the applications Gemfiles and noticed the unicorn gem. I decided to assume this is a production box and altered the application recipes to use Unicorn along with nginx.

Next Steps/Conclusion:

The next steps I would take would be to either expand the basic cookbooks I created or leverage a community cookbook. I also noted that gems were installed to the `/tmp/` directory, in general this is a bad location because it consumes your swap and will not survive reboots, I changed it to `/var/tmp/` but it really should have a new home. If this were true production we would also need to profile the cpu and memory utilization and adjust workers and configs for optimal performance. Additional work could be done to create 2 environments for Production and Development.

A final note, I did use a lot of small commits to help illustrate my workflow. 

Thanks for your time.
James Brink
